### PR TITLE
Fixed AclCache doc comment

### DIFF
--- a/Acl/Model/AclCache.php
+++ b/Acl/Model/AclCache.php
@@ -196,7 +196,7 @@ class AclCache implements AclCacheInterface
     /**
      * Returns the key for the object identity
      *
-     * @param ObjectIdentityInterface $oid
+     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $oid
      *
      * @return string
      */


### PR DESCRIPTION
Travis is failing because a doc block param comment is not meeting standards.
