### PR TITLE
Fix the default ports in the SymfonyBridge layer

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -108,16 +108,17 @@ class SymfonyBridgeAdapter
         }
 
         if (in_array($type, array('memcache', 'memcached'))) {
+            $host = !empty($host) ? $host : 'localhost';
             $config[$type]['servers'][$host] = array(
                 'host' => $host,
-                'port' => $port,
+                'port' => !empty($port) ? $port : 11211,
             );
         }
 
         if ($type === 'redis') {
             $config[$type] = array(
-                'host' => $host,
-                'port' => $port,
+                'host' => !empty($host) ? $host : 'localhost',
+                'port' => !empty($port) ? $port : 6379,
                 'password' => null,
                 'database' => null
             );


### PR DESCRIPTION
The behavior needs to be the same than in the Symfony bridge.
Closes doctrine/DoctrineBundle#345

Please merge this very quickly and release it, so that it can be there before the Symfony 2.6 release done today.
