### PR TITLE
Remove IDE-specific files from the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ build
 composer.phar
 composer.lock
 phpunit.xml
-/nbproject/
-/.idea/


### PR DESCRIPTION
The right place to ignore these files is in local setups (potentially globally), not in project ignore rules
