### PR TITLE
Urgent: Namespace being ignored

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -105,6 +105,8 @@ class SymfonyBridgeAdapter
             $namespace   = 'sf2' . $this->mappingResourceName .'_' . $objectManagerName . '_' . $hash;
 
             $config['namespace'] = $namespace;
+        } else {
+            $config['namespace'] = $cacheDriver['namespace'];
         }
 
         if (in_array($type, array('memcache', 'memcached'))) {


### PR DESCRIPTION
If you define the namespace it's being set to null, thus defining the same namespace for all classes, which would be an empty namespace.

I wrote urgent because this makes having two installations of the same project with namespaces defined unusable, since they'll then share the cache.