### PR TITLE
Always add namespace to config

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -104,8 +104,10 @@ class SymfonyBridgeAdapter
             $hash        = hash('sha256', $environment);
             $namespace   = 'sf2' . $this->mappingResourceName .'_' . $objectManagerName . '_' . $hash;
 
-            $config['namespace'] = $namespace;
+            $cacheDriver['namespace'] = $namespace;
         }
+        
+        $config['namespace'] = $cacheDriver['namespace'];
 
         if (in_array($type, array('memcache', 'memcached'))) {
             $host = !empty($host) ? $host : 'localhost';


### PR DESCRIPTION
The namespace set in the application config was never used in the $config['namespace'].