### PR TITLE
Getting rid of unnecesary symfony/framework-bundle dependency

### DIFF
--- a/Command/CacheCommand.php
+++ b/Command/CacheCommand.php
@@ -2,7 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineCacheBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\Common\Cache\Cache;
 
@@ -11,8 +12,13 @@ use Doctrine\Common\Cache\Cache;
  *
  * @author Alan Doucette <dragonwize@gmail.com>
  */
-abstract class CacheCommand extends ContainerAwareCommand
+abstract class CacheCommand extends Command implements ContainerAwareInterface
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
     /**
      * Get the requested cache provider service.
      *
@@ -39,5 +45,21 @@ abstract class CacheCommand extends ContainerAwareCommand
         }
 
         return $cacheProvider;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    protected function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,11 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.2",
-        "symfony/security":         "~2.2",
-        "symfony/framework-bundle": "~2.2",
-        "symfony/doctrine-bridge":  "~2.2",
-        "doctrine/inflector":       "~1.0",
-        "doctrine/cache":           "~1.3"
+        "php":                     ">=5.3.2",
+        "symfony/security":        "~2.2",
+        "symfony/doctrine-bridge": "~2.2",
+        "doctrine/inflector":      "~1.0",
+        "doctrine/cache":          "~1.3"
     },
     "require-dev": {
         "phpunit/phpunit":                       "~4",
@@ -45,6 +44,7 @@
         "symfony/validator":                     "~2.2",
         "symfony/console":                       "~2.2",
         "symfony/finder":                        "~2.2",
+        "symfony/framework-bundle":              "~2.2",
         "instaclick/coding-standard":            "~1.1",
         "satooshi/php-coveralls":                "~0.6.1",
         "squizlabs/php_codesniffer":             "~1.5",


### PR DESCRIPTION
This pull-request suggests to have CacheCommand as an implementation of ContainerAwareInterface instead of being a children class of ContainerAwareCommand which required to have symfony/framework-bundle installed.

Issue: #40 