### PR TITLE
Replace setFactory{Method,Service} by setFactory

### DIFF
--- a/DependencyInjection/Definition/MongodbDefinition.php
+++ b/DependencyInjection/Definition/MongodbDefinition.php
@@ -54,8 +54,7 @@ class MongodbDefinition extends CacheDefinition
         $connRef        = $this->getConnectionReference($name, $config, $container);
 
         $container->setDefinition($collId, $collDef)
-            ->setFactoryMethod('selectCollection')
-            ->setFactoryService($connRef)
+            ->setFactory(array($connRef, 'selectCollection'))
             ->setPublic(false);
 
         return new Reference($collId);

--- a/Tests/DependencyInjection/Fixtures/config/xml/service_parameter.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/service_parameter.xml
@@ -45,7 +45,8 @@
             <srv:argument>localhost:27017</srv:argument>
         </srv:service>
 
-        <srv:service id="my_mongodb_collection_service" class="%doctrine_cache.mongodb.collection.class%" factory-service="my_mongodb_connection_service" factory-method="selectCollection">
+        <srv:service id="my_mongodb_collection_service" class="%doctrine_cache.mongodb.collection.class%">
+            <srv:factory service="my_mongodb_connection_service" method="selectCollection"/>
             <srv:argument>my_database</srv:argument>
             <srv:argument>my_cache_collection</srv:argument>
         </srv:service>

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,12 @@
         }
     ],
     "require": {
-        "php":                     ">=5.3.2",
-        "symfony/security":        "~2.2",
-        "symfony/doctrine-bridge": "~2.2",
-        "doctrine/inflector":      "~1.0",
-        "doctrine/cache":          "~1.3"
+        "php":                          ">=5.3.2",
+        "symfony/security":             "~2.2",
+        "symfony/doctrine-bridge":      "~2.2",
+        "doctrine/inflector":           "~1.0",
+        "doctrine/cache":               "~1.3",
+        "symfony/dependency-injection": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit":                       "~4",


### PR DESCRIPTION
Make the method compatible with future Symfony version, and avoid
E_USER_DEPRECATED as thrown by the current 2.7.0-beta2:

The Symfony\Component\DependencyInjection\Definition::setFactoryMethod
method is deprecated since version 2.6 and will be removed in 3.0. Use
Definition::setFactory() instead.

The Symfony\Component\DependencyInjection\Definition::setFactoryService
method is deprecated since version 2.6 and will be removed in 3.0. Use
Definition::setFactory() instead.