### PR TITLE
Update Redis options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ $aclCache = $this->container->get('security.acl.cache');
     - connection_id - Redis connection service id
     - host          - redis host
     - port          - redis port
+    - database      - redis database selection (integer)
 #### riak
     - connection_id                 - Riak\Connection service id
     - bucket_id                     - Riak\Bucket service id


### PR DESCRIPTION
According to https://github.com/doctrine/DoctrineCacheBundle/blob/master/DependencyInjection/Definition/RedisDefinition.php#L63
there is a `database` option for redis driver.