### PR TITLE
Fixed Illegal offset type in isset or empty

### DIFF
--- a/DependencyInjection/Definition/MongodbDefinition.php
+++ b/DependencyInjection/Definition/MongodbDefinition.php
@@ -60,7 +60,7 @@ class MongodbDefinition extends CacheDefinition
         ;
         $container->setDefinition($doctrineCollFactoryId, $doctrineCollFactoryDef);
 
-        $collClass = 'MongoCollection';
+        $collClass = '%doctrine_cache.mongodb.collection.class%';
         $collId = sprintf('doctrine_cache.services.%s.collection', $name);
         $collDef = new Definition($collClass);
         $collDef


### PR DESCRIPTION
Fixed the container offset issue #68. I also noticed master is broken:

    Catchable Fatal Error: Argument 1 passed to Doctrine\Common\Cache\MongoDBCache::__construct() must be an instance of MongoCollection, instance of Doctrine\MongoDB\LoggableCollection given

My setup is the equivalent of:

    doctrine_cache.services.mongo_cache.collection.factory:
        class: %doctrine_cache.mongodb.collection.class%
        factory: ["@doctrine_mongodb.odm.default_connection", selectCollection]
        arguments:
            - %mongo_database%
            - cache

    doctrine_cache.services.mongo_cache.collection:
        class: MongoCollection
        factory: ["@doctrine_cache.services.mongo_cache.collection.factory", getMongoCollection]