### PR TITLE
Moving security-acl to an optional dependency

### DIFF
--- a/DependencyInjection/DoctrineCacheExtension.php
+++ b/DependencyInjection/DoctrineCacheExtension.php
@@ -77,7 +77,7 @@ class DoctrineCacheExtension extends Extension
             return;
         }
 
-        if (!interface_exists('Symfony\Component\Security\Acl\Model\AclInterface')) {
+        if ( ! interface_exists('Symfony\Component\Security\Acl\Model\AclInterface')) {
             throw new \LogicException('You must install symfony/security-acl in order to use the acl_cache functionality.');
         }
 

--- a/DependencyInjection/DoctrineCacheExtension.php
+++ b/DependencyInjection/DoctrineCacheExtension.php
@@ -77,6 +77,10 @@ class DoctrineCacheExtension extends Extension
             return;
         }
 
+        if (!interface_exists('Symfony\Component\Security\Acl\Model\AclInterface')) {
+            throw new \LogicException('You must install symfony/security-acl in order to use the acl_cache functionality.');
+        }
+
         $aclCacheDefinition = new Definition(
             $container->getParameter('doctrine_cache.security.acl.cache.class'),
             array(

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     ],
     "require": {
         "php":                     ">=5.3.2",
-        "symfony/security-acl":    "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.2|~3.0",
         "doctrine/inflector":      "~1.0",
         "doctrine/cache":          "^1.4.2"
@@ -46,11 +45,15 @@
         "symfony/console":                       "~2.2|~3.0",
         "symfony/finder":                        "~2.2|~3.0",
         "symfony/framework-bundle":              "~2.2|~3.0",
+        "symfony/security-acl":                  "~2.3|~3.0",
         "instaclick/coding-standard":            "~1.1",
         "satooshi/php-coveralls":                "~0.6.1",
         "squizlabs/php_codesniffer":             "~1.5",
         "instaclick/object-calisthenics-sniffs": "dev-master",
         "instaclick/symfony2-coding-standard":   "dev-remaster"
+    },
+    "suggest": {
+        "symfony/security-acl": "For using this bundle to cache ACLs"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\": "" }


### PR DESCRIPTION
Fixes #76 

I believe symfony/security-acl isn't *used* by anything, but this bundle provides a cache layer for it (if you're using it).

This should also help https://github.com/doctrine/DoctrineBundle/pull/486#issuecomment-159664695

Thanks!