### PR TITLE
Fix mangling of memcache/d hostnames

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -285,6 +285,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('connection_id')->defaultNull()->end()
                 ->arrayNode('servers')
                 ->useAttributeAsKey('host')
+                ->normalizeKeys(false)
                     ->prototype('array')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) {
@@ -329,6 +330,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('connection_id')->defaultNull()->end()
                 ->arrayNode('servers')
                 ->useAttributeAsKey('host')
+                ->normalizeKeys(false)
                     ->prototype('array')
                         ->beforeNormalization()
                             ->ifTrue(function ($v) {


### PR DESCRIPTION
When specifying a host like:
```
            memcached:
                servers:
                    %memcache_host%: %memcache_port%
```
the hostname gets mangled from 'localhost-asd' to 'localhost_asd'. This change will prevent the mangling. See http://symfony.com/doc/current/components/config/definition.html#array-node-options

The following workaround also works:
```
            memcached:
                servers:
                    default_memcache:
                      host: %memcache_host%
                      port: %memcache_port%
```