### PR TITLE
Add persistent id to memcached configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -327,6 +327,7 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('server')
             ->children()
                 ->scalarNode('connection_id')->defaultNull()->end()
+                ->scalarNode('persistent_id')->defaultNull()->end()
                 ->arrayNode('servers')
                 ->useAttributeAsKey('host')
                     ->prototype('array')

--- a/DependencyInjection/Definition/MemcachedDefinition.php
+++ b/DependencyInjection/Definition/MemcachedDefinition.php
@@ -49,6 +49,9 @@ class MemcachedDefinition extends CacheDefinition
         $connClass  = '%doctrine_cache.memcached.connection.class%';
         $connId     = sprintf('doctrine_cache.services.%s.connection', $name);
         $connDef    = new Definition($connClass);
+        if (isset($config['persistent_id']) === true) {
+            $connDef->addArgument($config['persistent_id']);
+        }
 
         foreach ($config['servers'] as $host => $server) {
             $connDef->addMethodCall('addServer', array($host, $server['port']));

--- a/DependencyInjection/Definition/MemcachedDefinition.php
+++ b/DependencyInjection/Definition/MemcachedDefinition.php
@@ -49,6 +49,7 @@ class MemcachedDefinition extends CacheDefinition
         $connClass  = '%doctrine_cache.memcached.connection.class%';
         $connId     = sprintf('doctrine_cache.services.%s.connection', $name);
         $connDef    = new Definition($connClass);
+
         if (isset($config['persistent_id']) === true) {
             $connDef->addArgument($config['persistent_id']);
         }

--- a/Resources/config/schema/doctrine_cache-1.0.xsd
+++ b/Resources/config/schema/doctrine_cache-1.0.xsd
@@ -52,6 +52,7 @@
             <xsd:element name="server" type="memcached_server" minOccurs="1" maxOccurs="unbounded" />
             <xsd:element name="connection-id" type="xsd:string" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
+        <xsd:attribute name="persistent-id" type="xsd:string"/>
         <xsd:attribute name="connection-id" type="xsd:string"/>
     </xsd:complexType>
 

--- a/Tests/Functional/Fixtures/Memcached.php
+++ b/Tests/Functional/Fixtures/Memcached.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional\Fixtures;
+
+
+class Memcached extends \Memcached
+{
+    protected $persistentId;
+
+    public function __construct($persistent_id = null, $callback = null)
+    {
+        parent::__construct($persistent_id, $callback);
+        $this->persistentId = $persistent_id;
+    }
+
+    public function getPersistentId()
+    {
+        return $this->persistentId;
+    }
+}

--- a/Tests/Functional/Fixtures/config/memcached.xml
+++ b/Tests/Functional/Fixtures/config/memcached.xml
@@ -7,7 +7,7 @@
 
     <doctrine-cache>
         <provider name="my_memcached_cache">
-            <memcached>
+            <memcached persistent-id="app">
                 <server host="127.0.0.1" port="11211"/>
             </memcached>
         </provider>

--- a/Tests/Functional/MemcachedCacheTest.php
+++ b/Tests/Functional/MemcachedCacheTest.php
@@ -20,7 +20,6 @@
 
 namespace Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional;
 
-use Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional\Fixtures\Memcached;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -53,7 +52,7 @@ class MemcachedCacheTest extends BaseCacheTest
 
     protected function overrideContainer(ContainerBuilder $container)
     {
-        $container->setParameter('doctrine_cache.memcached.connection.class', Memcached::class);
+        $container->setParameter('doctrine_cache.memcached.connection.class', 'Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional\Fixtures\Memcached');
     }
 
     /**

--- a/Tests/Functional/MemcachedCacheTest.php
+++ b/Tests/Functional/MemcachedCacheTest.php
@@ -20,12 +20,21 @@
 
 namespace Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional;
 
+use Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional\Fixtures\Memcached;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 /**
  * @group Functional
  * @group Memcached
  */
 class MemcachedCacheTest extends BaseCacheTest
 {
+    public function testPersistentId()
+    {
+        $cache = $this->createCacheDriver();
+        $this->assertEquals('app', $cache->getMemcached()->getPersistentId());
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -40,6 +49,11 @@ class MemcachedCacheTest extends BaseCacheTest
         if (@fsockopen('localhost', 11211) === false) {
             $this->markTestSkipped('The ' . __CLASS__ .' cannot connect to memcached');
         }
+    }
+
+    protected function overrideContainer(ContainerBuilder $container)
+    {
+        $container->setParameter('doctrine_cache.memcached.connection.class', Memcached::class);
     }
 
     /**

--- a/Tests/FunctionalTestCase.php
+++ b/Tests/FunctionalTestCase.php
@@ -51,8 +51,19 @@ class FunctionalTestCase extends TestCase
 
         $container->registerExtension($loader);
         $this->loadFromFile($container, $file);
+        $this->overrideContainer($container);
         $container->compile();
 
         return $container;
+    }
+
+    /**
+     * Override this hook in your functional TestCase to customize the container
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function overrideContainer(ContainerBuilder $container)
+    {
+
     }
 }


### PR DESCRIPTION
This pull request allows the end user to define a "persistent-id" for the Memcached constructor.