### PR TITLE
Tests fix for DoctrineCache 1.6 : Proposal #1

### DIFF
--- a/Tests/Functional/Command/StatsCommandTest.php
+++ b/Tests/Functional/Command/StatsCommandTest.php
@@ -41,6 +41,21 @@ class StatsCommandTest extends CommandTestCase
         $this->tester->execute(array(
             'cache-name' => $this->cacheName,
         ));
-        $this->assertEquals("Stats were not provided for the {$this->cacheName} provider of type Doctrine\\Common\\Cache\\ArrayCache\n", $this->tester->getDisplay());
+        $stats = $this->tester->getDisplay();
+
+        if (strpos($stats, 'Stats were not') === false) {
+            // This test is for Doctrine/Cache >= 1.6.0 only
+            $this->assertRegExp(
+                "/^Stats for the {$this->cacheName} provider of type Doctrine\\\Common\\\Cache\\\ArrayCache:
+\[hits] 0
+\[misses] 0
+\[uptime] [0-9]{10}
+\[memory_usage] \n\[memory_available] \n$/sm",
+                $stats
+            );
+        } else {
+            // This test is for Doctrine/Cache < 1.6.0 only
+            $this->assertEquals("Stats were not provided for the {$this->cacheName} provider of type Doctrine\\Common\\Cache\\ArrayCache\n", $this->tester->getDisplay());
+        }
     }
 }


### PR DESCRIPTION
Since DoctrineCache 1.6.0, tests are broken because the ArrayCache is now giving some stats. As I'm not sure for the cleaner way to resolve this issue, this is a first proposal.