### PR TITLE
Tests fix for DoctrineCache 1.6: Proposal #2

### DIFF
--- a/Tests/Functional/Command/StatsCommandTest.php
+++ b/Tests/Functional/Command/StatsCommandTest.php
@@ -41,6 +41,25 @@ class StatsCommandTest extends CommandTestCase
         $this->tester->execute(array(
             'cache-name' => $this->cacheName,
         ));
-        $this->assertEquals("Stats were not provided for the {$this->cacheName} provider of type Doctrine\\Common\\Cache\\ArrayCache\n", $this->tester->getDisplay());
+
+        $stats = $this->tester->getDisplay();
+
+        if (strpos($stats, 'Stats were not') === false) {
+            // This test is for Doctrine/Cache >= 1.6.0 only
+            $this->assertStringStartsWith(
+                "Stats for the {$this->cacheName} provider of type Doctrine\\Common\\Cache\\ArrayCache:",
+                $stats
+            );
+            $this->assertContains("[hits] 0\n", $stats);
+            $this->assertContains("[misses] 0\n", $stats);
+            $this->assertRegExp('/\[uptime\] [0-9]{10}' . "\n/", $stats);
+            $this->assertContains("[memory_usage] \n", $stats);
+            $this->assertContains("[memory_available] \n", $stats);
+        } else {
+            // This test is for Doctrine/Cache < 1.6.0 only
+            $this->assertEquals("Stats were not provided for the {$this->cacheName} provider of type Doctrine\\Common\\Cache\\ArrayCache\n", $this->tester->getDisplay());
+        }
+
+
     }
 }


### PR DESCRIPTION
Since DoctrineCache 1.6.0, tests are broken because the ArrayCache is now giving some stats.
As I'm not sure for the cleaner way to resolve this issue, this is a second proposal.