### PR TITLE
Pass through predis configuration in symfony bridge

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -128,6 +128,17 @@ class SymfonyBridgeAdapter
             );
         }
 
+        if ($type === 'predis') {
+            $config[$type] = array(
+                'scheme' => 'tcp',
+                'host' => !empty($host) ? $host : 'localhost',
+                'port' => !empty($port) ? $port : 6379,
+                'password' => !empty($password) ? $password : null,
+                'database' => !empty($database) ? $database : 0,
+                'timeout' => null,
+            );
+        }
+
         $this->cacheProviderLoader->loadCacheProvider($id, $config, $container);
 
         return $id;


### PR DESCRIPTION
This PR makes it possible to use predis as cache driver under the `metadata_cache_driver`, `query_cache_driver` and `result_cache_driver` keys in your doctrine configuration.