### PR TITLE
allow to use persistent redis connections

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -377,6 +377,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('password')->defaultNull()->end()
                 ->scalarNode('timeout')->defaultNull()->end()
                 ->scalarNode('database')->defaultNull()->end()
+                ->booleanNode('persistent')->defaultFalse()->end()
             ->end()
         ;
 

--- a/DependencyInjection/Definition/RedisDefinition.php
+++ b/DependencyInjection/Definition/RedisDefinition.php
@@ -57,14 +57,20 @@ class RedisDefinition extends CacheDefinition
             $connParams[] = $config['timeout'];
         }
 
+        $connMethod = 'connect';
+
+        if (isset($config['persistent']) && $config['persistent']) {
+            $connMethod = 'pconnect';
+        }
+
         $connDef->setPublic(false);
-        $connDef->addMethodCall('connect', $connParams);
+        $connDef->addMethodCall($connMethod, $connParams);
 
         if (isset($config['password'])) {
             $password = $config['password'];
             $connDef->addMethodCall('auth', array($password));
         }
-        
+
         if (isset($config['database'])) {
             $database = (int) $config['database'];
             $connDef->addMethodCall('select', array($database));

--- a/Resources/config/schema/doctrine_cache-1.0.xsd
+++ b/Resources/config/schema/doctrine_cache-1.0.xsd
@@ -100,6 +100,7 @@
         <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="timeout" type="xsd:unsignedInt" />
         <xsd:attribute name="database" type="xsd:unsignedInt" />
+        <xsd:attribute name="persistent" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- predis -->

--- a/Resources/doc/reference.rst
+++ b/Resources/doc/reference.rst
@@ -109,6 +109,8 @@ This provider defines no configuration options.
     Redis connection timeout
 ``database``
     Redis database selection (integer)
+``persistent``
+    Whether to use persistent connection or not (bool)
 
 ``predis``
 ~~~~~~~~~~

--- a/Tests/Functional/Fixtures/config/redis.xml
+++ b/Tests/Functional/Fixtures/config/redis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<srv:container xmlns="http://doctrine-project.org/schemas/symfony-dic/cache"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:srv="http://symfony.com/schema/dic/services"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://doctrine-project.org/schemas/symfony-dic/cache http://doctrine-project.org/schemas/symfony-dic/cache/doctrine_cache-1.0.xsd">
+
+    <doctrine-cache>
+        <provider name="my_redis_cache">
+            <redis host="127.0.0.1" port="6379" />
+        </provider>
+        <provider name="my_persistent_redis_cache">
+            <redis host="127.0.0.1" port="6379" persistent="true" />
+        </provider>
+    </doctrine-cache>
+</srv:container>

--- a/Tests/Functional/RedisCacheTest.php
+++ b/Tests/Functional/RedisCacheTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\DoctrineCacheBundle\Tests\Functional;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Redis Driver Test
+ *
+ * @group Functional
+ * @group Redis
+ * @author Tomasz Wójcik <tomasz.prgtw.wojcik@gmail.com>
+ */
+class RedisCacheTest extends BaseCacheTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function createCacheDriver()
+    {
+        if ( ! extension_loaded('redis')) {
+            $this->markTestSkipped('The ' . __CLASS__ .' requires the redis extension');
+        }
+
+        if (false === @fsockopen('localhost', 6379)) {
+            $this->markTestSkipped('The ' . __CLASS__ .' cannot connect to redis');
+        }
+
+        $container = $this->compileContainer('redis');
+        $cache     = $container->get('doctrine_cache.providers.my_redis_cache');
+
+        return $cache;
+    }
+
+    /**
+     * @dataProvider provideProviders
+     *
+     * @param string $serviceId
+     * @param string $methodUsed
+     */
+    public function testPersistentConnection($serviceId, $methodUsed)
+    {
+        $container = $this->compileContainer('redis');
+        $definition = $container->getDefinition($serviceId);
+        $calls = $definition->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        /** @var Definition $redisDefinition */
+        $redisDefinition = $calls[0][1][0];
+        $this->assertTrue($redisDefinition->hasMethodCall($methodUsed));
+    }
+
+    public function provideProviders()
+    {
+        return array(
+            'not_persistent' => array('doctrine_cache.providers.my_redis_cache', 'connect'),
+            'persistent' => array('doctrine_cache.providers.my_persistent_redis_cache', 'pconnect'),
+        );
+    }
+}


### PR DESCRIPTION
New ``persistent`` configuration option for Redis introduced. It allows the connection to be persistent by internally switching connection method from `\Redis::connect` to `\Redis::pconnect`