### PR TITLE
Updated doctrine:cache:stats cache-name argument description

### DIFF
--- a/Command/StatsCommand.php
+++ b/Command/StatsCommand.php
@@ -20,7 +20,7 @@ class StatsCommand extends CacheCommand
     {
         $this->setName('doctrine:cache:stats')
             ->setDescription('Get stats on a given cache provider')
-            ->addArgument('cache-name', InputArgument::REQUIRED, 'Which cache provider to flush?');
+            ->addArgument('cache-name', InputArgument::REQUIRED, 'For which cache provider would you like to get stats?');
     }
 
     /**


### PR DESCRIPTION
The old description asks 'Which cache provider to flush?' but the command doesn't flush the cache provider but provides stats.