### PR TITLE
Fix missing namespace when using custom_provider

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -117,6 +117,7 @@ class Configuration implements ConfigurationInterface
                 $options = reset($params);
                 $conf    = array(
                     'type'            => 'custom_provider',
+                    'namespace'       => $conf['namespace'] ?: null,
                     'custom_provider' => array(
                         'type'      => $conf['type'],
                         'options'   => $options ?: null,


### PR DESCRIPTION
This is a minor change to add the missing namespace for custom providers. This should fix #103.
