### PR TITLE
Use cache.prefix.seed parameter when available

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -102,9 +102,15 @@ class SymfonyBridgeAdapter
 
         if ( ! isset($cacheDriver['namespace'])) {
             // generate a unique namespace for the given application
-            $environment = $container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment');
-            $hash        = hash('sha256', $environment);
-            $namespace   = 'sf2' . $this->mappingResourceName .'_' . $objectManagerName . '_' . $hash;
+            $seed = '_'.$container->getParameter('kernel.root_dir');
+
+            if ($container->hasParameter('cache.prefix.seed')) {
+                $seed = '.'.$container->getParameterBag()->resolveValue($container->getParameter('cache.prefix.seed'));
+            }
+
+            $seed .= '.'.$container->getParameter('kernel.name').'.'.$container->getParameter('kernel.environment').'.'.$container->getParameter('kernel.debug');
+            $hash      = hash('sha256', $seed);
+            $namespace = 'sf_' . $this->mappingResourceName .'_' . $objectManagerName . '_' . $hash;
 
             $cacheDriver['namespace'] = $namespace;
         }

--- a/Tests/DependencyInjection/SymfonyBridgeAdapterTest.php
+++ b/Tests/DependencyInjection/SymfonyBridgeAdapterTest.php
@@ -114,6 +114,31 @@ class SymfonyBridgeAdpterTest extends TestCase
         $this->assertTrue($container->hasAlias('doctrine.orm.default_metadata_cache'));
     }
 
+    public function testCacheDriverPrefixSeed()
+    {
+        $container   = $this->createServiceContainer();
+        $definition  = new Definition('%doctrine.orm.cache.apc.class%');
+        $cacheDriver = array(
+            'type' => 'apc',
+            'id'   => 'service_driver'
+        );
+
+        $container->setParameter('cache.prefix.seed', 'foo');
+        $container->setDefinition('service_driver', $definition);
+
+        $this->adapter->loadCacheDriver('metadata_cache', 'default', $cacheDriver, $container);
+
+        $service = $container->findDefinition('doctrine.orm.default_metadata_cache');
+
+        $expectedMethodCalls = array(
+            array(
+                'setNamespace',
+                array('sf_orm_default_2eb4176f7637ca5687b4a9530b97e686a1ad6ff953a9e2dbef24e07adf8946d7')
+            )
+        );
+        $this->assertSame($expectedMethodCalls, $service->getMethodCalls());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage "unrecognized_type" is an unrecognized Doctrine cache driver.

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -45,6 +45,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
             'kernel.bundles'     => $mappings,
             'kernel.environment' => 'test',
             'kernel.root_dir'    => __DIR__.'/../',
+            'kernel.name'        => 'test',
             'kernel.cache_dir'   => sys_get_temp_dir(),
         )));
     }


### PR DESCRIPTION
As done on Symfony in https://github.com/symfony/symfony/pull/20616