### PR TITLE
Allow providers to be loaded lazy

### DIFF
--- a/DependencyInjection/CacheProviderLoader.php
+++ b/DependencyInjection/CacheProviderLoader.php
@@ -51,6 +51,10 @@ class CacheProviderLoader
             $container->setAlias($alias, $serviceId);
         }
 
+        if ($config['lazy']) {
+            $service->setLazy(true);
+        }
+
         if ($this->definitionClassExists($type, $container)) {
             $this->getCacheDefinition($type, $container)->configure($name, $config, $service, $container);
         }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -173,6 +173,7 @@ class Configuration implements ConfigurationInterface
                             ->then($normalization)
                         ->end()
                         ->children()
+                            ->scalarNode('lazy')->defaultFalse()->end()
                             ->scalarNode('namespace')->defaultNull()->end()
                             ->scalarNode('type')->defaultNull()->end()
                             ->append($this->addBasicProviderNode('apc'))

--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -98,6 +98,7 @@ class SymfonyBridgeAdapter
             $type       => array(),
             'type'      => $type,
             'namespace' => null,
+            'lazy'      => false
         );
 
         if ( ! isset($cacheDriver['namespace'])) {

--- a/Tests/DependencyInjection/AbstractDoctrineCacheExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineCacheExtensionTest.php
@@ -290,6 +290,24 @@ abstract class AbstractDoctrineCacheExtensionTest extends TestCase
         $this->compileContainer('unrecognized');
     }
 
+    public function testLazy()
+    {
+        $container = $this->compileContainer('lazy');
+
+        $providers = array(
+            'doctrine_cache.providers.lazy_provider' => true,
+            'doctrine_cache.providers.lazy_false_provider' => false,
+            'doctrine_cache.providers.lazy_no_provider'   => false,
+        );
+
+        foreach ($providers as $key => $lazy) {
+            $this->assertTrue($container->hasDefinition($key));
+            $definition = $container->getDefinition($key);
+            $this->assertTrue($definition->isLazy() == $lazy);
+        }
+
+    }
+
     public function testAcl()
     {
         $container = $this->compileContainer('acl');
@@ -315,7 +333,6 @@ abstract class AbstractDoctrineCacheExtensionTest extends TestCase
 
         $this->assertTrue($definition->isPublic());
         $this->assertEquals($class, $definition->getClass());
-
         foreach (array_unique($expectedCalls) as $methodName => $params) {
             $this->assertMethodCall($definition, $methodName, $params);
         }

--- a/Tests/DependencyInjection/Fixtures/config/xml/lazy.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/lazy.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<srv:container xmlns="http://doctrine-project.org/schemas/symfony-dic/cache"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://doctrine-project.org/schemas/symfony-dic/cache http://doctrine-project.org/schemas/symfony-dic/cache/doctrine_cache-1.0.xsd">
+
+    <doctrine-cache>
+
+        <provider name="lazy_provider" type="apc">
+            <lazy>true</lazy>
+        </provider>
+        <provider name="lazy_false_provider" type="array">
+            <lazy>false</lazy>
+        </provider>
+        <provider name="lazy_no_provider" type="array">
+        </provider>
+
+    </doctrine-cache>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/lazy.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/lazy.yml
@@ -1,0 +1,11 @@
+doctrine_cache:
+    providers:
+        lazy_provider:
+            type: apc
+            lazy: true
+        lazy_false_provider:
+            type: array
+            lazy: false
+        lazy_no_provider:
+            type: redis
+            lazy: false

--- a/Tests/DependencyInjection/Fixtures/config/yml/lazy.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/lazy.yml
@@ -8,4 +8,3 @@ doctrine_cache:
             lazy: false
         lazy_no_provider:
             type: redis
-            lazy: false


### PR DESCRIPTION
Currently, providers are not loaded lazy and there's no easy way (or I didn't find out) to let them load lazy. The problem is, that if you inject such a provider into a class in symfony, there is no easy way to catch an exception happening during constructing the class. And at least in the redis provider, an exception happens simply when the redis server is not reachable (which for a cache shouldn't lead in an not easy catchable exception). When lazy loading the provider, we can handle this case with a common try/catch construct in the get/set calls

