### PR TITLE
Add command registration to fix Symfony 3.4 auto-registration deprecation

### DIFF
--- a/DoctrineCacheBundle.php
+++ b/DoctrineCacheBundle.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Bundle\DoctrineCacheBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -29,4 +30,10 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class DoctrineCacheBundle extends Bundle
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function registerCommands(Application $application)
+    {
+    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -68,6 +68,18 @@
         <service id="doctrine_cache.abstract.wincache" class="%doctrine_cache.wincache.class%" abstract="true" />
         <service id="doctrine_cache.abstract.xcache" class="%doctrine_cache.xcache.class%" abstract="true" />
         <service id="doctrine_cache.abstract.zenddata" class="%doctrine_cache.zenddata.class%" abstract="true" />
+        <service id="doctrine_cache.contains_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\ContainsCommand" public="false">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_cache.delete_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\DeleteCommand" public="false">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_cache.flush_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\FlushCommand" public="false">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_cache.stats_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\StatsCommand" public="false">
+            <tag name="console.command" />
+        </service>
     </services>
 
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -68,16 +68,16 @@
         <service id="doctrine_cache.abstract.wincache" class="%doctrine_cache.wincache.class%" abstract="true" />
         <service id="doctrine_cache.abstract.xcache" class="%doctrine_cache.xcache.class%" abstract="true" />
         <service id="doctrine_cache.abstract.zenddata" class="%doctrine_cache.zenddata.class%" abstract="true" />
-        <service id="doctrine_cache.contains_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\ContainsCommand" public="false">
+        <service id="doctrine_cache.contains_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\ContainsCommand">
             <tag name="console.command" />
         </service>
-        <service id="doctrine_cache.delete_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\DeleteCommand" public="false">
+        <service id="doctrine_cache.delete_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\DeleteCommand">
             <tag name="console.command" />
         </service>
-        <service id="doctrine_cache.flush_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\FlushCommand" public="false">
+        <service id="doctrine_cache.flush_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\FlushCommand">
             <tag name="console.command" />
         </service>
-        <service id="doctrine_cache.stats_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\StatsCommand" public="false">
+        <service id="doctrine_cache.stats_command" class="Doctrine\Bundle\DoctrineCacheBundle\Command\StatsCommand">
             <tag name="console.command" />
         </service>
     </services>


### PR DESCRIPTION
Commands auto-registration is deprecated in Symfony 3.4. This PR will avoid Auto-registration of the command "Doctrine\Bundle\DoctrineCacheBundle\Command\xxx" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead. exceptions.