### PR TITLE
[DOC] Fix identation for memcache/memcached provider

### DIFF
--- a/Resources/doc/reference.rst
+++ b/Resources/doc/reference.rst
@@ -69,6 +69,7 @@ This provider defines no configuration options.
     Server list
 
     * ``server``
+
       * ``host``, Memcache host
       * ``port``, Memcache port
 
@@ -81,6 +82,7 @@ This provider defines no configuration options.
     Server list
 
     * ``server``
+
       * ``host``, Memcached host
       * ``port``, Memcached port
 


### PR DESCRIPTION
From the sphinx documentation:  Nested lists are possible, but be aware that they must be separated from the parent list items by blank lines: