### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Acl/Model/AclCacheTest.php
+++ b/Tests/Acl/Model/AclCacheTest.php
@@ -8,8 +8,9 @@ use Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy;
 use Symfony\Component\Security\Acl\Domain\Acl;
 use Doctrine\Bundle\DoctrineCacheBundle\Acl\Model\AclCache;
 use Doctrine\Common\Cache\ArrayCache;
+use PHPUnit\Framework\TestCase;
 
-class AclCacheTest extends \PHPUnit_Framework_TestCase
+class AclCacheTest extends TestCase
 {
     /**
      * @var \Doctrine\Common\Cache\ArrayCache

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -23,8 +23,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     /**
      * @param array $bundles
@@ -49,7 +50,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
             'kernel.cache_dir'   => sys_get_temp_dir(),
         )));
     }
-    
+
     /**
      * @param array $bundles
      * @param string $vendor

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/cache":          "^1.4.2"
     },
     "require-dev": {
-        "phpunit/phpunit":                       "~4",
+        "phpunit/phpunit":                       "~4.8.35",
         "symfony/phpunit-bridge":                "~2.7|~3.3|~4.0",
         "symfony/yaml":                          "~2.7|~3.3|~4.0",
         "symfony/validator":                     "~2.7|~3.3|~4.0",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.