### PR TITLE
Use createMock instead of deprecated getMock

### DIFF
--- a/Tests/Functional/Command/CommandTestCase.php
+++ b/Tests/Functional/Command/CommandTestCase.php
@@ -73,7 +73,7 @@ class CommandTestCase extends FunctionalTestCase
      */
     private function getMockKernel()
     {
-        $mock = $this->getMock('\Symfony\Component\HttpKernel\Kernel', array(), array(), '', false, false);
+        $mock = $this->createMock('\Symfony\Component\HttpKernel\Kernel', array(), array(), '', false, false);
         $mock->method('getBundles')->willReturn(array());
         $mock->method('getContainer')->willReturn($this->container);
         return $mock;
@@ -86,6 +86,6 @@ class CommandTestCase extends FunctionalTestCase
      */
     private function getMockFilesystem()
     {
-        return $this->getMock('\Symfony\Bundle\FrameworkBundle\Util\Filesystem', array(), array(), '', false, false);
+        return $this->createMock('\Symfony\Bundle\FrameworkBundle\Util\Filesystem', array(), array(), '', false, false);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/cache":          "^1.4.2"
     },
     "require-dev": {
-        "phpunit/phpunit":                       "~4",
+        "phpunit/phpunit":                       "~5.4",
         "symfony/phpunit-bridge":                "~2.7|~3.3|~4.0",
         "symfony/yaml":                          "~2.7|~3.3|~4.0",
         "symfony/validator":                     "~2.7|~3.3|~4.0",


### PR DESCRIPTION
getMock has been deprecated since PHPUnit 5.4, and removed in PHPUnit 6.
This drops support for PHPUnit 4, but that version is not supported
upstream anymore since February 3, 2017.

This may be taken into consideration in order to help migrate to recent
PHPUnit with <https://github.com/doctrine/DoctrineCacheBundle/pull/124>.

Bug-Debian: https://bugs.debian.org/882898