### PR TITLE
Exclude tests from Composer's classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,10 @@
         "symfony/security-acl": "For using this bundle to cache ACLs"
     },
     "autoload": {
-        "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\": "" }
+        "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This is a little performance improvement. If the optimised dumped classmap is generated, the tests should not be part of it.

Documentation: https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps