### PR TITLE
Make all tests pass on Symfony 4

### DIFF
--- a/DependencyInjection/CacheProviderLoader.php
+++ b/DependencyInjection/CacheProviderLoader.php
@@ -2,6 +2,7 @@
 namespace Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection;
 
 use Doctrine\Common\Inflector\Inflector;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -28,9 +29,10 @@ class CacheProviderLoader
         if ($config['namespace']) {
             $service->addMethodCall('setNamespace', array($config['namespace']));
         }
+        $service->setPublic(true);
 
         foreach ($config['aliases'] as $alias) {
-            $container->setAlias($alias, $serviceId);
+            $container->setAlias($alias, new Alias($serviceId, true));
         }
 
         if ($this->definitionClassExists($type, $container)) {

--- a/DependencyInjection/DoctrineCacheExtension.php
+++ b/DependencyInjection/DoctrineCacheExtension.php
@@ -2,6 +2,7 @@
 namespace Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -95,7 +96,7 @@ class DoctrineCacheExtension extends Extension
     protected function loadCacheAliases(array $rootConfig, ContainerBuilder $container)
     {
         foreach ($rootConfig['aliases'] as $alias => $name) {
-            $container->setAlias($alias, 'doctrine_cache.providers.' . $name);
+            $container->setAlias($alias, new Alias('doctrine_cache.providers.' . $name, true));
         }
     }
 

--- a/Tests/DependencyInjection/AbstractDoctrineCacheExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractDoctrineCacheExtensionTest.php
@@ -353,7 +353,10 @@ abstract class AbstractDoctrineCacheExtensionTest extends TestCase
 
         $compilerPassConfig = $container->getCompilerPassConfig();
 
-        $compilerPassConfig->setOptimizationPasses(array(new ResolveDefinitionTemplatesPass()));
+        $pass = class_exists('Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass')
+            ? 'Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass'
+            : 'Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass';
+        $compilerPassConfig->setOptimizationPasses(array(new $pass()));
         $compilerPassConfig->setRemovingPasses(array());
 
         $this->loadFromFile($container, $file);


### PR DESCRIPTION
Two minor fixes to make tests pass on SF4:
* `ResolveDefinitionTemplatesPass` was removed from Symfony 4, so added a test to use `ResolveChildDefinitionsPass` if it exists.
* Make the server aliases public (not the default since SF4).