### PR TITLE
Add PHP 7.2 to tested versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: php
 sudo: false
-dist: precise
+dist: trusty
 
-php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - nightly
-    - hhvm
+cache:
+    directories:
+        - $HOME/.composer/cache
 
 services:
     - riak
@@ -22,7 +16,7 @@ before_script:
     - ./Tests/travis/install-deps.sh
     - composer self-update
     - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-    - composer update --prefer-source
+    - composer update --prefer-dist
 
 script:
     - ./vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
@@ -32,9 +26,19 @@ after_script:
     - php ./vendor/bin/coveralls -v
 
 matrix:
+    exclude:
+        - php: 5.3
+          dist: trusty
     allow_failures:
         - php: nightly
-        - php: hhvm
     include:
+        - php: 5.3
+          dist: precise
+        - php: 5.4
+        - php: 5.5
         - php: 5.6
           env: DEPS="dev"
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+        - php: nightly

--- a/Tests/travis/install-deps.sh
+++ b/Tests/travis/install-deps.sh
@@ -6,5 +6,12 @@ if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then
     exit 0;
 fi
 
+VERSION_NAME=$(phpenv version-name)
+
+if [ $VERSION_NAME = "5.3" ] || [ $VERSION_NAME = "5.4" ] || [ $VERSION_NAME = "5.5" ] || [ $VERSION_NAME = "5.6" ]; then
+    echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+fi
+
 pecl install riak
 phpenv config-add $BASEDIR/php.ini

--- a/Tests/travis/php.ini
+++ b/Tests/travis/php.ini
@@ -1,5 +1,3 @@
-extension="mongo.so"
-extension="memcache.so"
 extension="memcached.so"
 
 apc.enabled=1

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/cache":          "^1.4.2"
     },
     "require-dev": {
-        "phpunit/phpunit":                       "~4",
+        "phpunit/phpunit":                       "~4|~5",
         "symfony/phpunit-bridge":                "~2.7|~3.3|~4.0",
         "symfony/yaml":                          "~2.7|~3.3|~4.0",
         "symfony/validator":                     "~2.7|~3.3|~4.0",


### PR DESCRIPTION
- Test on PHP 7.2
- Prefer dist over source for composer install
- Remove HHVM
- Use composer cache
- Allow phpunit 5 (to avoid using phpunit 4 that make test fails on PHP7.2 due to a `each` usage)