### PR TITLE
Don't include tests and tooling config in distributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/Resources/doc
 /Tests export-ignore
 /.coveralls.yml export-ignore
 /.gitattributes export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/Tests export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/ruleset.xml export-ignore

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,13 @@
         "symfony/security-acl": "For using this bundle to cache ACLs"
     },
     "autoload": {
-        "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\": "" }
+        "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": { "Doctrine\\Bundle\\DoctrineCacheBundle\\Tests\\": "Tests" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
* Don't include tests when installed via composer 
* Don't add tests to classmap when installing with `--no-dev`
* Don't add documentation sources to distributions
* Don't add tooling configuration to distributions.

This PR supersedes #130.