### PR TITLE
Remove a TreeBuilder deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,8 +86,8 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $self            = $this;
-        $builder         = new TreeBuilder();
-        $node            = $builder->root('doctrine_cache', 'array');
+        $builder         = new TreeBuilder('doctrine_cache');
+        $node            = $builder->getRootNode();
         $normalization   = function ($conf) use ($self, $builder) {
             $conf['type'] = isset($conf['type'])
                 ? $conf['type']
@@ -198,8 +198,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addBasicProviderNode($name)
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root($name);
+        $builder = new TreeBuilder($name);
+        $node    = $builder->getRootNode();
 
         return $node;
     }
@@ -211,8 +211,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addCustomProviderNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('custom_provider');
+        $builder = new TreeBuilder('custom_provider');
+        $node    = $builder->getRootNode();
 
         $node
             ->children()
@@ -234,8 +234,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addChainNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('chain');
+        $builder = new TreeBuilder('chain');
+        $node    = $builder->getRootNode();
 
         $node
             ->fixXmlConfig('provider')
@@ -256,8 +256,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addMemcacheNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('memcache');
+        $builder = new TreeBuilder('memcache');
+        $node    = $builder->getRootNode();
         $host    = '%doctrine_cache.memcache.host%';
         $port    = '%doctrine_cache.memcache.port%';
 
@@ -301,8 +301,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addMemcachedNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('memcached');
+        $builder = new TreeBuilder('memcached');
+        $node    = $builder->getRootNode();
         $host    = '%doctrine_cache.memcached.host%';
         $port    = '%doctrine_cache.memcached.port%';
 
@@ -347,8 +347,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addRedisNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('redis');
+        $builder = new TreeBuilder('redis');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -373,8 +373,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addPredisNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('predis');
+        $builder = new TreeBuilder('predis');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -403,8 +403,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addRiakNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('riak');
+        $builder = new TreeBuilder('riak');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -433,8 +433,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addCouchbaseNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('couchbase');
+        $builder = new TreeBuilder('couchbase');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -461,8 +461,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addMongoNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('mongodb');
+        $builder = new TreeBuilder('mongodb');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -485,8 +485,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addPhpFileNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('php_file');
+        $builder = new TreeBuilder('php_file');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -507,8 +507,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addFileSystemNode()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('file_system');
+        $builder = new TreeBuilder('file_system');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -529,8 +529,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addSqlite3Node()
     {
-        $builder = new TreeBuilder();
-        $node    = $builder->root('sqlite3');
+        $builder = new TreeBuilder('sqlite3');
+        $node    = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()


### PR DESCRIPTION
As shown in https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config

This was spotted while upgrading [Symfony Demo app](https://github.com/symfony/demo) to 4.2.x-dev:

![deprecation-5](https://user-images.githubusercontent.com/73419/46810532-2b85fd00-cd71-11e8-9d63-aa0a11bcebf7.png)
