### PR TITLE
[Doc] Add class returned by cache provider services

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -45,6 +45,8 @@ services anywhere in your application::
     $metadataCache = $this->container->get('doctrine_cache.providers.my_apc_metadata_cache');
     $queryCache = $this->container->get('doctrine_cache.providers.my_apc_query_cache');
 
+Both ``metadataCache`` and ``$queryCache`` are instances of ``Doctrine\Common\Cache\CacheProvider``.
+
 Service Aliases
 ---------------
 


### PR DESCRIPTION
When reading the documentation for the first time, it can be helpful to know which class is returned