### PR TITLE
Disable composer memory limit for failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ matrix:
     include:
         - php: 5.3
           dist: precise
+          env: COMPOSER_MEMORY_LIMIT=-1
         - php: 5.4
         - php: 5.5
         - php: 5.6
-          env: DEPS="dev"
+          env: DEPS="dev" COMPOSER_MEMORY_LIMIT=-1
         - php: 7.0
         - php: 7.1
         - php: 7.2


### PR DESCRIPTION
This PR disables the memory limit for builds running on PHP 5.3 and the build installing dev dependencies as those were continuously running out of memory.