### PR TITLE
Remove int cast that prevents setting redis database from env var

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -358,7 +358,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')->defaultValue('%doctrine_cache.redis.port%')->end()
                 ->scalarNode('password')->defaultNull()->end()
                 ->scalarNode('timeout')->defaultNull()->end()
-                ->scalarNode('database')->defaultNull()->end()
+                ->integerNode('database')->defaultNull()->end()
                 ->booleanNode('persistent')->defaultFalse()->end()
             ->end()
         ;

--- a/DependencyInjection/Definition/RedisDefinition.php
+++ b/DependencyInjection/Definition/RedisDefinition.php
@@ -72,7 +72,7 @@ class RedisDefinition extends CacheDefinition
         }
 
         if (isset($config['database'])) {
-            $database = (int) $config['database'];
+            $database = $config['database'];
             $connDef->addMethodCall('select', array($database));
         }
 


### PR DESCRIPTION
Setting redis database from env var is impossible today due to int casting since the var has not been interpreted by symfony yet.