### PR TITLE
Add deprecation warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Master: [![Build Status](https://secure.travis-ci.org/doctrine/DoctrineCacheBund
 
 Master: [![Coverage Status](https://coveralls.io/repos/doctrine/DoctrineCacheBundle/badge.png?branch=master)](https://coveralls.io/r/doctrine/DoctrineCacheBundle?branch=master)
 
+## Deprecation warning
+
+This bundle is deprecated; it will not be updated for Symfony 5. If you want to
+use doctrine/cache in Symfony, please configure the services manually. When
+using Symfony, we no longer recommend configuring doctrine/cache through this
+bundle. Instead, you should use symfony/cache for your cache needs. However, the
+deprecation does not extend to doctrine/cache, you'll be able to use those
+classes as you did so far.
+
 ## Installation
 
 1. Add this bundle to your project as a composer dependency:


### PR DESCRIPTION
Add deprecation notice, see https://github.com/doctrine/DoctrineCacheBundle/issues/156#issuecomment-496805411. Ping @dbu - not quite sure if the paragraph is enough or if we want to add more information: DoctrineBundle communicates the deprecation in more detail and shows alternatives for people using it implicitly.