### PR TITLE
Fix a bug in doctrine.yaml configuration

### DIFF
--- a/DependencyInjection/SymfonyBridgeAdapter.php
+++ b/DependencyInjection/SymfonyBridgeAdapter.php
@@ -115,6 +115,14 @@ class SymfonyBridgeAdapter
                 'database' => !empty($database) ? $database : 0
             );
         }
+        
+        if ($type === 'php_file') {
+            $config[$type] = array(
+                'directory' => '%kernel.cache_dir%/doctrine/cache/phpfile',
+                'extension' => null,
+                'umask' => 0002
+            );
+        }
 
         if ($type === 'predis') {
             $config[$type] = array(


### PR DESCRIPTION
Without this i had an error when I tried to use following configuration in config/doctrine.yaml:
```
        result_cache_driver:
            type: php_file
```
This should be possible to use because it's implemented, but it's not included in SymfonyBridgeAdatper.php and configuration.

## This bundle became deprecated

Please be aware that this bundle became deprecated and won't be compatible with Symfony 5 and upwards.
Read more about the deprecation and the alternatives for this bundle in the issue 
[#156](https://github.com/doctrine/DoctrineCacheBundle/issues/156).
